### PR TITLE
Move credentials to vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+To test the credentials, create a vault.json file in the directory above the git directory. Paste the following JSON and update the value for the username and the password properties:
+
+{
+  "robotsparebin": {
+    "username": "username-here",
+    "password": "password-here"
+  }
+}
+
 # Template: Standard Robot Framework
 
 Want to get started using [Robot Framework](https://robocorp.com/docs/languages-and-frameworks/robot-framework/basics) this is the simplest template to start from.

--- a/devdata/env.json
+++ b/devdata/env.json
@@ -1,0 +1,5 @@
+{
+    "RPA_SECRET_MANAGER": "RPA.Robocorp.Vault.FileSecrets",
+    "RPA_SECRET_FILE": "C:\\Users\\Anne\\Documents\\Projets\\Robocorp\\vault.json"
+  }
+  

--- a/tasks.robot
+++ b/tasks.robot
@@ -5,6 +5,7 @@ Library    RPA.HTTP
 Library    RPA.Excel.Files
 Library    RPA.PDF
 Library    String
+Library    RPA.Robocorp.Vault
 
 *** Tasks ***
 Insert the sales data for the week and export it as a PDF
@@ -21,8 +22,9 @@ Open the intranet website
     Open Available Browser    https://robotsparebinindustries.com/
 
 Log in
-    Input Text   username    maria
-    Input Password    password    thoushallnotpass
+    ${secret}=  Get Secret    robotsparebin
+    Input Text   username    ${secret}[username]
+    Input Password    password    ${secret}[password]
     Submit Form
     Wait Until Page Contains Element    id:sales-form
 


### PR DESCRIPTION
This pull request removes the hard-coded login credentials from the robot to a vault for better security.

To test this, create a vault.json file in the directory above the git directory. Paste the following JSON and update the value for the username and the password properties:
```
{
  "robotsparebin": {
    "username": "username-here",
    "password": "password-here"
  }
}
```